### PR TITLE
Sumup additions 

### DIFF
--- a/lib/cnab240/arquivo/arquivo.rb
+++ b/lib/cnab240/arquivo/arquivo.rb
@@ -43,7 +43,7 @@ module Cnab240::Arquivo
 			File.open(filename, 'w') {|f| f.write(string) }
 		end
 
-		def self.load_from_file(file, version)
+		def self.load_from_file(file, version = nil)
 			Cnab240::Builder.new(file, version).arquivos
 		end
 


### PR DESCRIPTION
Changes include:
- Implementation fo v83 layout
- Auto filling of number of registrations in batch trailer
- Add option to include explicit version when loading from file
- Accept both file name and file object when loading from file
- Don't use git in gem building - that will allow to build the gem on environments that don't have git 
- Ignore unknown segments when parsing file

The only incompatible change with the previous versions would be the last one - ignore unknown segments when parsing file. This feature is useful if a file contains too many segments that you don't care about, don't need to implement and can be safely ignored. Additional method to validate that the file contains only expected segments can be added to allow more flexibility.
