### PR TITLE
Modularização da Versão dos Helpers

### DIFF
--- a/lib/cnab240/helper/boleto_bancoob.rb
+++ b/lib/cnab240/helper/boleto_bancoob.rb
@@ -7,14 +7,15 @@ module Cnab240
       campos[:arquivo_data_geracao] ||= (Time.respond_to?(:current) ? Time.current : Time.now).strftime('%d%m%Y')
       campos[:arquivo_hora_geracao] ||= (Time.respond_to?(:current) ? Time.current : Time.now).strftime('%H%M%S')
       campos[:arquivo_codigo] ||= '1'
+      campos[:versao] ||= 'V81'
 
-      @arquivo = Cnab240::Arquivo::Arquivo.new('V81')
+      @arquivo = Cnab240::Arquivo::Arquivo.new(campos[:versao])
 
       fill campos, arquivo.header, arquivo.trailer
     end
 
     def add_lote(campos = {})
-      @arquivo.lotes << lote = Cnab240::Lote.new(operacao: :boleto, tipo: :remessa, versao: 'V81')
+      @arquivo.lotes << lote = Cnab240::Lote.new(operacao: :boleto, tipo: :remessa, versao: campos[:versao])
 
       campos[:controle_banco] ||= '756'
       campos[:controle_lote] = (@arquivo.lotes.length).to_s

--- a/lib/cnab240/helper/boleto_bancoob.rb
+++ b/lib/cnab240/helper/boleto_bancoob.rb
@@ -53,7 +53,7 @@ module Cnab240
       campos[:controle_lote] = @arquivo.lotes.length.to_s
       campos[:servico_numero_registro] = (lote.segmentos.length + 1).to_s
 
-      segmento_s = Cnab240::V81::SegmentoS.new
+      segmento_s = Cnab240.const_get(campos[:versao])::SegmentoS.new
       fill campos, segmento_s
       lote << segmento_s
     end

--- a/lib/cnab240/helper/boleto_bancoob.rb
+++ b/lib/cnab240/helper/boleto_bancoob.rb
@@ -15,6 +15,9 @@ module Cnab240
     end
 
     def add_lote(campos = {})
+
+      campos[:versao] ||= 'V81'
+
       @arquivo.lotes << lote = Cnab240::Lote.new(operacao: :boleto, tipo: :remessa, versao: campos[:versao])
 
       campos[:controle_banco] ||= '756'
@@ -32,21 +35,23 @@ module Cnab240
       # 01 - Entrada de títulos
       campos[:servico_codigo_movimento] ||= '01'
 
-      segmento_p = Cnab240::V81::SegmentoP.new
+      campos[:versao] ||= 'V81'
+
+      segmento_p = Cnab240.const_get(campos[:versao])::SegmentoP.new
       fill campos, segmento_p
       lote << segmento_p
 
       campos[:controle_lote] = @arquivo.lotes.length.to_s
       campos[:servico_numero_registro] = (lote.segmentos.length + 1).to_s
 
-      segmento_q = Cnab240::V81::SegmentoQ.new
+      segmento_q = Cnab240.const_get(campos[:versao])::SegmentoQ.new
       fill campos, segmento_q
       lote << segmento_q
 
       campos[:controle_lote] = @arquivo.lotes.length.to_s
       campos[:servico_numero_registro] = (lote.segmentos.length + 1).to_s
 
-      segmento_r = Cnab240::V81::SegmentoR.new
+      segmento_r = Cnab240.const_get(campos[:versao])::SegmentoR.new
       fill campos, segmento_r
       lote << segmento_r
 

--- a/lib/cnab240/helper/pagamento_bb.rb
+++ b/lib/cnab240/helper/pagamento_bb.rb
@@ -21,6 +21,8 @@ module Cnab240
     end
 
     def add_lote(campos = {})
+      campos[:versao] ||= 'V86'
+
       @arquivo.lotes << lote = Cnab240::Lote.new(operacao: :pagamento, tipo: :remessa, versao: campos[:versao])
 
       campos[:servico_operacao] ||= 'C'
@@ -39,6 +41,7 @@ module Cnab240
       campos[:servico_tipo_movimento] ||= '000'
       campos[:credito_moeda_tipo] ||= 'BRL'
       campos[:totais_qtde_registros] ||= (lote.segmentos.length + 2).to_s
+      campos[:versao] ||= 'V86'
 
       segmento_a = Cnab240.const_get(campos[:versao])::SegmentoA.new
       fill campos, segmento_a

--- a/lib/cnab240/helper/pagamento_bb.rb
+++ b/lib/cnab240/helper/pagamento_bb.rb
@@ -40,7 +40,7 @@ module Cnab240
       campos[:credito_moeda_tipo] ||= 'BRL'
       campos[:totais_qtde_registros] ||= (lote.segmentos.length + 2).to_s
 
-      segmento_a = Cnab240::V86::SegmentoA.new
+      segmento_a = Cnab240.const_get(campos[:versao])::SegmentoA.new
       fill campos, segmento_a
       # fill campos, segmento_a.favorecido_agencia_conta
 

--- a/lib/cnab240/helper/pagamento_bb.rb
+++ b/lib/cnab240/helper/pagamento_bb.rb
@@ -7,9 +7,10 @@ module Cnab240
       campos[:arquivo_data_geracao] ||= (Time.respond_to?(:current) ? Time.current : Time.now).strftime('%d%m%Y')
       campos[:arquivo_hora_geracao] ||= (Time.respond_to?(:current) ? Time.current : Time.now).strftime('%H%M%S')
       campos[:arquivo_codigo] ||= '1'
+      campos[:versao] ||= 'V86'
 
-      @arquivo = Cnab240::Arquivo::Arquivo.new('V86')
-      @arquivo.lotes << lote = Cnab240::Lote.new(operacao: :pagamento, tipo: :remessa, versao: 'V86')
+      @arquivo = Cnab240::Arquivo::Arquivo.new(campos[:versao])
+      @arquivo.lotes << lote = Cnab240::Lote.new(operacao: :pagamento, tipo: :remessa, versao: campos[:versao])
 
       fill campos, arquivo.header, arquivo.trailer
 
@@ -20,7 +21,7 @@ module Cnab240
     end
 
     def add_lote(campos = {})
-      @arquivo.lotes << lote = Cnab240::Lote.new(operacao: :pagamento, tipo: :remessa, versao: 'V86')
+      @arquivo.lotes << lote = Cnab240::Lote.new(operacao: :pagamento, tipo: :remessa, versao: campos[:versao])
 
       campos[:servico_operacao] ||= 'C'
       campos[:controle_lote] ||= '0001'

--- a/lib/cnab240/helper/pagamento_bradesco.rb
+++ b/lib/cnab240/helper/pagamento_bradesco.rb
@@ -38,7 +38,7 @@ module Cnab240
       campos[:credito_moeda_tipo] ||= 'REA'
       campos[:totais_qtde_registros] ||= (lote.segmentos.length + 2).to_s
 
-      segmento_a = Cnab240::V80::SegmentoA.new
+      segmento_a = Cnab240.const_get(campos[:versao])::SegmentoA.new
       fill campos, segmento_a
       fill campos, segmento_a.favorecido_agencia_conta
 

--- a/lib/cnab240/helper/pagamento_bradesco.rb
+++ b/lib/cnab240/helper/pagamento_bradesco.rb
@@ -6,9 +6,10 @@ module Cnab240
       campos[:banco_nome] ||= 'BANCO BRADESCO'
       campos[:arquivo_data_geracao] ||= (Time.respond_to?(:current) ? Time.current : Time.now).strftime('%d%m%Y')
       campos[:arquivo_hora_geracao] ||= (Time.respond_to?(:current) ? Time.current : Time.now).strftime('%H%M%S')
+      campos[:versao] ||= 'V80'
 
-      @arquivo = Cnab240::Arquivo::Arquivo.new('V80')
-      @arquivo.lotes << lote = Cnab240::Lote.new(operacao: :pagamento, tipo: :remessa, versao: 'V80')
+      @arquivo = Cnab240::Arquivo::Arquivo.new(campos[:versao])
+      @arquivo.lotes << lote = Cnab240::Lote.new(operacao: :pagamento, tipo: :remessa, versao: campos[:versao])
 
       fill campos, arquivo.header, arquivo.trailer
 
@@ -19,7 +20,7 @@ module Cnab240
     end
 
     def add_lote(campos = {})
-      @arquivo.lotes << lote = Cnab240::Lote.new(operacao: :pagamento, tipo: :remessa, versao: 'V80')
+      @arquivo.lotes << lote = Cnab240::Lote.new(operacao: :pagamento, tipo: :remessa, versao: campos[:versao])
 
       campos[:servico_operacao] ||= 'C'
       campos[:controle_lote] ||= '0001'

--- a/lib/cnab240/helper/pagamento_bradesco.rb
+++ b/lib/cnab240/helper/pagamento_bradesco.rb
@@ -20,6 +20,8 @@ module Cnab240
     end
 
     def add_lote(campos = {})
+      campos[:versao] ||= 'V80'
+
       @arquivo.lotes << lote = Cnab240::Lote.new(operacao: :pagamento, tipo: :remessa, versao: campos[:versao])
 
       campos[:servico_operacao] ||= 'C'
@@ -37,6 +39,7 @@ module Cnab240
       campos[:servico_tipo_movimento] ||= '000'
       campos[:credito_moeda_tipo] ||= 'REA'
       campos[:totais_qtde_registros] ||= (lote.segmentos.length + 2).to_s
+      campos[:versao] ||= 'V80'
 
       segmento_a = Cnab240.const_get(campos[:versao])::SegmentoA.new
       fill campos, segmento_a

--- a/lib/cnab240/helper/pagamento_itau.rb
+++ b/lib/cnab240/helper/pagamento_itau.rb
@@ -38,7 +38,7 @@ module Cnab240
       campos[:credito_moeda_tipo] ||= 'REA'
       campos[:totais_qtde_registros] ||= (lote.segmentos.length + 2).to_s
 
-      segmento_a = Cnab240::V80::SegmentoA.new
+      segmento_a = Cnab240.const_get(campos[:versao])::SegmentoA.new
       fill campos, segmento_a
       fill campos, segmento_a.favorecido_agencia_conta
 

--- a/lib/cnab240/helper/pagamento_itau.rb
+++ b/lib/cnab240/helper/pagamento_itau.rb
@@ -20,6 +20,7 @@ module Cnab240
     end
 
     def add_lote(campos = {})
+      campos[:versao] ||= 'V80'
       @arquivo.lotes << lote = Cnab240::Lote.new(operacao: :pagamento, tipo: :remessa, versao: campos[:versao])
 
       campos[:servico_operacao] ||= 'C'
@@ -37,6 +38,7 @@ module Cnab240
       campos[:servico_tipo_movimento] ||= '000'
       campos[:credito_moeda_tipo] ||= 'REA'
       campos[:totais_qtde_registros] ||= (lote.segmentos.length + 2).to_s
+      campos[:versao] ||= 'V80'
 
       segmento_a = Cnab240.const_get(campos[:versao])::SegmentoA.new
       fill campos, segmento_a

--- a/lib/cnab240/helper/pagamento_itau.rb
+++ b/lib/cnab240/helper/pagamento_itau.rb
@@ -6,9 +6,10 @@ module Cnab240
       campos[:banco_nome] ||= 'BANCO ITAU'
       campos[:arquivo_data_geracao] ||= (Time.respond_to?(:current) ? Time.current : Time.now).strftime('%d%m%Y')
       campos[:arquivo_hora_geracao] ||= (Time.respond_to?(:current) ? Time.current : Time.now).strftime('%H%M%S')
+      campos[:versao] ||= 'V80'
 
-      @arquivo = Cnab240::Arquivo::Arquivo.new('V80')
-      @arquivo.lotes << lote = Cnab240::Lote.new(operacao: :pagamento, tipo: :remessa, versao: 'V80')
+      @arquivo = Cnab240::Arquivo::Arquivo.new(campos[:versao])
+      @arquivo.lotes << lote = Cnab240::Lote.new(operacao: :pagamento, tipo: :remessa, versao: campos[:versao])
 
       fill campos, arquivo.header, arquivo.trailer
 
@@ -19,7 +20,7 @@ module Cnab240
     end
 
     def add_lote(campos = {})
-      @arquivo.lotes << lote = Cnab240::Lote.new(operacao: :pagamento, tipo: :remessa, versao: 'V80')
+      @arquivo.lotes << lote = Cnab240::Lote.new(operacao: :pagamento, tipo: :remessa, versao: campos[:versao])
 
       campos[:servico_operacao] ||= 'C'
       campos[:controle_lote] ||= '0001'

--- a/lib/cnab240/helper/transferencia_citibank.rb
+++ b/lib/cnab240/helper/transferencia_citibank.rb
@@ -36,7 +36,7 @@ module Cnab240
       # [018] TED (STR,CIP) ou [700] DOC.
       campos[:favorecido_camara] = favorecido_camara(lote, campos)
 
-      segmento_a = Cnab240::V60::SegmentoA.new
+      segmento_a = Cnab240.const_get(campos[:versao])::SegmentoA.new
       fill campos, segmento_a
       lote << segmento_a
 

--- a/lib/cnab240/helper/transferencia_citibank.rb
+++ b/lib/cnab240/helper/transferencia_citibank.rb
@@ -15,6 +15,8 @@ module Cnab240
     end
 
     def add_lote(campos = {})
+      campos[:versao] ||= 'V60'
+
       @arquivo.lotes << lote = Cnab240::Lote.new(operacao: :pagamento, tipo: :remessa, versao: campos[:versao])
 
       campos[:controle_banco] ||= '745'
@@ -35,6 +37,8 @@ module Cnab240
       campos[:credito_moeda_tipo] ||= 'BRL'
       # [018] TED (STR,CIP) ou [700] DOC.
       campos[:favorecido_camara] = favorecido_camara(lote, campos)
+
+      campos[:versao] ||= 'V60'
 
       segmento_a = Cnab240.const_get(campos[:versao])::SegmentoA.new
       fill campos, segmento_a

--- a/lib/cnab240/helper/transferencia_citibank.rb
+++ b/lib/cnab240/helper/transferencia_citibank.rb
@@ -7,14 +7,15 @@ module Cnab240
       campos[:arquivo_data_geracao] ||= (Time.respond_to?(:current) ? Time.current : Time.now).strftime('%d%m%Y')
       campos[:arquivo_hora_geracao] ||= (Time.respond_to?(:current) ? Time.current : Time.now).strftime('%H%M%S')
       campos[:arquivo_codigo] ||= '1'
+      campos[:versao] ||= 'V60'
 
-      @arquivo = Cnab240::Arquivo::Arquivo.new('V60')
+      @arquivo = Cnab240::Arquivo::Arquivo.new(campos[:versao])
 
       fill campos, arquivo.header, arquivo.trailer
     end
 
     def add_lote(campos = {})
-      @arquivo.lotes << lote = Cnab240::Lote.new(operacao: :pagamento, tipo: :remessa, versao: 'V60')
+      @arquivo.lotes << lote = Cnab240::Lote.new(operacao: :pagamento, tipo: :remessa, versao: campos[:versao])
 
       campos[:controle_banco] ||= '745'
       campos[:servico_operacao] ||= 'C'

--- a/lib/cnab240/helper/transferencia_sicoob.rb
+++ b/lib/cnab240/helper/transferencia_sicoob.rb
@@ -41,7 +41,7 @@ module Cnab240
       campos[:controle_lote] = @arquivo.lotes.length.to_s
       campos[:servico_numero_registro] = (lote.segmentos.length + 1).to_s
 
-      segmento_b = Cnab240::V87::SegmentoB.new
+      segmento_b = Cnab240.const_get(campos[:versao])::SegmentoB.new
       fill campos, segmento_b
       lote << segmento_b
     end

--- a/lib/cnab240/helper/transferencia_sicoob.rb
+++ b/lib/cnab240/helper/transferencia_sicoob.rb
@@ -15,6 +15,8 @@ module Cnab240
     end
 
     def add_lote(campos = {})
+      campos[:versao] ||= 'V87'
+
       @arquivo.lotes << lote = Cnab240::Lote.new(operacao: :pagamento, tipo: :remessa, versao: campos[:versao])
 
       campos[:controle_banco] ||= '756'
@@ -33,6 +35,8 @@ module Cnab240
       # 000 para inclusao e 999 para exclusao
       campos[:servico_tipo_movimento] ||= '000'
       campos[:credito_moeda_tipo] ||= 'BRL'
+
+      campos[:versao] ||= 'V87'
 
       segmento_a = Cnab240::V87::SegmentoA.new
       fill campos, segmento_a

--- a/lib/cnab240/helper/transferencia_sicoob.rb
+++ b/lib/cnab240/helper/transferencia_sicoob.rb
@@ -7,14 +7,15 @@ module Cnab240
       campos[:arquivo_data_geracao] ||= (Time.respond_to?(:current) ? Time.current : Time.now).strftime('%d%m%Y')
       campos[:arquivo_hora_geracao] ||= (Time.respond_to?(:current) ? Time.current : Time.now).strftime('%H%M%S')
       campos[:arquivo_codigo] ||= '1'
+      campos[:versao] ||= 'V87'
 
-      @arquivo = Cnab240::Arquivo::Arquivo.new('V87')
+      @arquivo = Cnab240::Arquivo::Arquivo.new(campos[:versao])
 
       fill campos, arquivo.header, arquivo.trailer
     end
 
     def add_lote(campos = {})
-      @arquivo.lotes << lote = Cnab240::Lote.new(operacao: :pagamento, tipo: :remessa, versao: 'V87')
+      @arquivo.lotes << lote = Cnab240::Lote.new(operacao: :pagamento, tipo: :remessa, versao: campos[:versao])
 
       campos[:controle_banco] ||= '756'
       campos[:servico_operacao] ||= 'C'


### PR DESCRIPTION
Ao tentar usar o helper de pagamento do Banco do Brasil, quis utilizar uma outra versão de layout (V83) e não a padrão do helper (V86). Sendo assim, editei as classes para que aceitem, de maneira parametrizada, a versão de layout para cada helper:

```
pagamento = Cnab240::PagamentoBb.new({versao: 'v83'})
```
